### PR TITLE
Rotate screen image if necessary

### DIFF
--- a/DMXVNCServer.hpp
+++ b/DMXVNCServer.hpp
@@ -156,7 +156,11 @@ private:
 
 	int m_padded_width{};
 	int m_pitch{};
+	int m_dmx_pitch{};
 	Rect m_frameRect{};
+
+	int m_dmx_width{};
+	int m_dmx_height{};
 
 	uint32_t  m_vc_image_ptr{};
 	

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CXXFLAGS = -Wall -std=c++11 -O3 -DHAVE_LIBBCM_HOST -DUSE_EXTERNAL_LIBBCM_HOST -D
 
 INCLUDES = -I/opt/vc/include/ -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux
 LIB_PATHS = -L/opt/vc/lib/
-LIBS = -lGLESv2 -lEGL -lopenmaxil -lbcm_host -lvcos -lvchiq_arm -lpthread -lrt -lvncserver -lconfig++
+LIBS = -lbrcmGLESv2 -lbrcmEGL -lopenmaxil -lbcm_host -lvcos -lvchiq_arm -lpthread -lrt -lvncserver -lconfig++
 
 SOURCES = main.cpp \
 		UFile.cpp \


### PR DESCRIPTION
If the screen is rotated or flipped by _display_hdmi_rotate_ or _display_lcd_rotate_ in _/boot/config.txt_ we need to rotate it back in order to display it correctly on the VNC server.
The rotation routine was taken from [https://github.com/AndrewFromMelbourne/raspi2png](url).

I have also adjusted the Makefile in order to make it compile on current Raspbian versions.