### PR TITLE
enable inetd support in dispmanx_vnc

### DIFF
--- a/DMXVNCServer.cpp
+++ b/DMXVNCServer.cpp
@@ -518,7 +518,7 @@ bool DMXVNCServer::TakePicture()
 		m_fpsCounter.GetFPS(), m_frameRect.left, m_frameRect.top, m_frameRect.right, m_frameRect.bottom);
 
 	if (m_lastPrintedMessage != printbuffer) {
-		std::cerr << printbuffer;
+		std::cout << printbuffer;
 		m_lastPrintedMessage = printbuffer;
 	}
 

--- a/DMXVNCServer.cpp
+++ b/DMXVNCServer.cpp
@@ -110,6 +110,7 @@ void DMXVNCServer::Run(int port, const std::string& password,
 						int screen, bool relativeMode, bool safeMode,
 						bool bandwidthMode, bool multiThreaded, bool downscale,
 						bool localhost,
+						bool inetd,
 						const std::string& vncParams)
 {
 	m_safeMode = safeMode;
@@ -143,6 +144,11 @@ void DMXVNCServer::Run(int port, const std::string& password,
 		m_server->port = port;
 	}
 	
+  if (inetd){
+		m_server->inetdSock= 0;
+		m_server->port = 0;
+  }
+
 	if(localhost) {
 		m_server->listen6Interface = localhost_address;
 		rfbStringToAddr(localhost_address, &m_server->listenInterface);

--- a/DMXVNCServer.cpp
+++ b/DMXVNCServer.cpp
@@ -111,6 +111,7 @@ void DMXVNCServer::Run(int port, const std::string& password,
 						bool bandwidthMode, bool multiThreaded, bool downscale,
 						bool localhost,
 						bool inetd,
+						bool once,
 						const std::string& vncParams)
 {
 	m_safeMode = safeMode;
@@ -118,6 +119,7 @@ void DMXVNCServer::Run(int port, const std::string& password,
 	m_screen = screen;
 	m_multiThreaded = multiThreaded;
 	m_downscale = downscale;
+	connect_once = once;
 
 	Open();
 
@@ -572,6 +574,15 @@ void DMXVNCServer::clientgone(rfbClientPtr cl)
 void DMXVNCServer::ClientGone(rfbClientPtr cl)
 {
 	m_clientCount--;
+	if(connect_once){
+		if(m_clientCount > 0){
+			Logger::Get() << m_clientCount << " other client" << ((m_clientCount > 1) ? "s" :"") <<	" still running";
+		}
+		else {
+			Logger::Get() << "Last client exited, terminating";
+			terminate = true;
+		}
+	}
 }
 
 void ImageMap::Resize(int height, int width)

--- a/DMXVNCServer.hpp
+++ b/DMXVNCServer.hpp
@@ -95,6 +95,7 @@ public:
 				int screen, bool relativeMode, bool safeMode,
 				bool bandwidthMode, bool multiThreaded, bool downscale,
 				bool localhost,
+				bool inetd,
 				const std::string& vncParams);
 
 private:

--- a/DMXVNCServer.hpp
+++ b/DMXVNCServer.hpp
@@ -96,6 +96,7 @@ public:
 				bool bandwidthMode, bool multiThreaded, bool downscale,
 				bool localhost,
 				bool inetd,
+				bool once,
 				const std::string& vncParams);
 
 private:
@@ -110,6 +111,7 @@ private:
 	enum rfbNewClientAction NewClient(rfbClientPtr cl);
 	static void clientgone(rfbClientPtr cl);
 	void ClientGone(rfbClientPtr cl);
+	bool connect_once;
 
 	const int BPP{2};
 	const VC_IMAGE_TYPE_T imageType{VC_IMAGE_RGB565};

--- a/dispmanx_vncserver.conf.sample
+++ b/dispmanx_vncserver.conf.sample
@@ -8,4 +8,5 @@ password = "";
 frame-rate = 15;
 downscale = false;
 localhost = false;
+inetd = false;
 vnc-params = "";

--- a/main.cpp
+++ b/main.cpp
@@ -38,6 +38,7 @@ struct ConfigData
 	bool multiThreaded = false;
 	bool localhost = false;
 	bool inetd = false;
+	bool once = false;
 	int frameRate = 15;
 	std::string configFile;
 	std::string vncParams;
@@ -80,6 +81,7 @@ int main(int argc, char *argv[])
 			"\tlocalhost = " << (configData.localhost ? "true" : "false") << "\n"
 			"\tinetd = " << (configData.inetd ? "true" : "false") << "\n"
 			"\tmulti-threaded = " << (configData.multiThreaded ? "true" : "false") << "\n"
+			"\tonce = " << (configData.once ? "true" : "false") << "\n"
 			"\tpassword = " << (configData.password.length() ? "***" : "") << "\n"
 			"\tport = " << configData.port << "\n"
 			"\trelative = " << (configData.relative ? "true" : "false") << "\n"
@@ -93,6 +95,7 @@ int main(int argc, char *argv[])
 									configData.multiThreaded, configData.downscale,
 									configData.localhost,
 									configData.inetd,
+									configData.once,
 									configData.vncParams);
 	}
 	catch (HelpException&) {
@@ -132,6 +135,7 @@ void GetCommandLineConfigData(int argc, char *argv[], ConfigData& configData)
 		{ "localhost", no_argument, nullptr, 'l' },
 		{ "inetd", no_argument, nullptr, 'i' },
 		{ "multi-threaded", no_argument, nullptr, 'm' },
+		{ "once", no_argument, nullptr, 'o' },
 		{ "password", required_argument, nullptr, 'P' },
 		{ "port", required_argument, nullptr, 'p' },
 		{ "screen", required_argument, nullptr, 's' },
@@ -143,7 +147,7 @@ void GetCommandLineConfigData(int argc, char *argv[], ConfigData& configData)
 
 	int c;
 	optind = 1;
-	while (-1 != (c = getopt_long(argc, argv, "abc:dfilmP:p:rs:t:uv:", long_options, nullptr))) {
+	while (-1 != (c = getopt_long(argc, argv, "abc:dfilmP:op:rs:t:uv:", long_options, nullptr))) {
 		switch (c) {
 		case 'a':
 			configData.relative = false;
@@ -179,6 +183,10 @@ void GetCommandLineConfigData(int argc, char *argv[], ConfigData& configData)
 
 		case 'm':
 			configData.multiThreaded = true;
+			break;
+
+		case 'o':
+			configData.once = true;
 			break;
 
 		case 'P':
@@ -252,6 +260,7 @@ bool ReadConfigFile(const char *programName, const std::string& configFile, Conf
 		config.lookupValue("localhost", configData.localhost);
 		config.lookupValue("inetd", configData.inetd);
 		config.lookupValue("multi-threaded", configData.multiThreaded);
+		config.lookupValue("once", configData.once);
 		config.lookupValue("password", configData.password);
 		config.lookupValue("port", configData.port);
 		config.lookupValue("screen", configData.screen);
@@ -292,6 +301,7 @@ void usage(const char *programName)
 		"  -i, --inetd                  stdio instead of listening socket\n"
 		"  -l, --localhost              only listens to local ports\n"
 		"  -m, --multi-threaded         runs vnc in a separate thread\n"
+		"  -o, --once                   connect once, then terminate\n"
 		"  -p, --port=PORT              makes vnc available on the speficied port\n"
 		"  -P, --password=PASSWORD      protects the session with PASSWORD\n"
 		"  -r, --relative               relative mouse movements\n"

--- a/main.cpp
+++ b/main.cpp
@@ -37,6 +37,7 @@ struct ConfigData
 	bool fullscreen = false;
 	bool multiThreaded = false;
 	bool localhost = false;
+	bool inetd = false;
 	int frameRate = 15;
 	std::string configFile;
 	std::string vncParams;
@@ -77,6 +78,7 @@ int main(int argc, char *argv[])
 			"\tdownscale = " << (configData.downscale ? "true" : "false") << "\n"
 			"\tfullscreen = " << (configData.fullscreen ? "true" : "false") << "\n"
 			"\tlocalhost = " << (configData.localhost ? "true" : "false") << "\n"
+			"\tinetd = " << (configData.inetd ? "true" : "false") << "\n"
 			"\tmulti-threaded = " << (configData.multiThreaded ? "true" : "false") << "\n"
 			"\tpassword = " << (configData.password.length() ? "***" : "") << "\n"
 			"\tport = " << configData.port << "\n"
@@ -90,6 +92,7 @@ int main(int argc, char *argv[])
 									configData.relative, !configData.unsafe, !configData.fullscreen,
 									configData.multiThreaded, configData.downscale,
 									configData.localhost,
+									configData.inetd,
 									configData.vncParams);
 	}
 	catch (HelpException&) {
@@ -127,6 +130,7 @@ void GetCommandLineConfigData(int argc, char *argv[], ConfigData& configData)
 		{ "unsafe", no_argument, nullptr, 'u' },
 		{ "fullscreen", no_argument, nullptr, 'f' },
 		{ "localhost", no_argument, nullptr, 'l' },
+		{ "inetd", no_argument, nullptr, 'i' },
 		{ "multi-threaded", no_argument, nullptr, 'm' },
 		{ "password", required_argument, nullptr, 'P' },
 		{ "port", required_argument, nullptr, 'p' },
@@ -139,7 +143,7 @@ void GetCommandLineConfigData(int argc, char *argv[], ConfigData& configData)
 
 	int c;
 	optind = 1;
-	while (-1 != (c = getopt_long(argc, argv, "abc:dflmP:p:rs:t:uv:", long_options, nullptr))) {
+	while (-1 != (c = getopt_long(argc, argv, "abc:dfilmP:p:rs:t:uv:", long_options, nullptr))) {
 		switch (c) {
 		case 'a':
 			configData.relative = false;
@@ -167,6 +171,10 @@ void GetCommandLineConfigData(int argc, char *argv[], ConfigData& configData)
 
 		case 'l':
 			configData.localhost = true;
+			break;
+
+		case 'i':
+			configData.inetd = true;
 			break;
 
 		case 'm':
@@ -242,6 +250,7 @@ bool ReadConfigFile(const char *programName, const std::string& configFile, Conf
 		config.lookupValue("downscale", configData.downscale);
 		config.lookupValue("fullscreen", configData.fullscreen);
 		config.lookupValue("localhost", configData.localhost);
+		config.lookupValue("inetd", configData.inetd);
 		config.lookupValue("multi-threaded", configData.multiThreaded);
 		config.lookupValue("password", configData.password);
 		config.lookupValue("port", configData.port);
@@ -280,6 +289,7 @@ void usage(const char *programName)
 		"  -c, --config-file=FILE       use the specified configuration file\n"
 		"  -d, --downscale              downscales the screen to a quarter in vnc\n"
 		"  -f, --fullscreen             always runs fullscreen mode\n"
+		"  -i, --inetd                  stdio instead of listening socket\n"
 		"  -l, --localhost              only listens to local ports\n"
 		"  -m, --multi-threaded         runs vnc in a separate thread\n"
 		"  -p, --port=PORT              makes vnc available on the speficied port\n"


### PR DESCRIPTION
This PR adds inetd support in dispmanx_vnc, making it compatible with systemd socket activation. The inetd mode is activated via the '--inetd' / '-i' switch.
A dispmanx_vnc client started with systemd may quit on client disconnecting, allowing systemd to handle the socket listener part, reducing the memory footprint on the raspberry pi. Terminating the process on disconnection is activated with the '-once' / '-o' switch.
For log capture reasons, frame stats are now published on standard output. 